### PR TITLE
bugfix: fix login failure as admin

### DIFF
--- a/playbooks/group_vars/fab.yml
+++ b/playbooks/group_vars/fab.yml
@@ -36,7 +36,7 @@ fab_manager_config_database:
 
 fab_manager_env:
   # XXX webpack needs a lot of memory
-  NODE_OPTIONS: '"--max-old-space-size=2048"'
+  NODE_OPTIONS: "--max-old-space-size=2048"
   # XXX disable color in active record
   NO_COLOR: "yes"
   RAILS_ENV: "{{ project_rails_env }}"
@@ -44,19 +44,19 @@ fab_manager_env:
   # https://github.com/sleede/fab-manager/blob/master/doc/environment.md
   POSTGRES_HOST: "{{ fab_manager_db_host }}"
   POSTGRES_USERNAME: "{{ fab_manager_db_user }}"
-  POSTGRES_PASSWORD: '"{{ fab_manager_db_password }}"'
+  POSTGRES_PASSWORD: "{{ fab_manager_db_password }}"
   REDIS_HOST: "{{ fab_manager_redis_host }}"
   ELASTICSEARCH_HOST: "{{ fab_manager_es_host }}"
 
   SECRET_KEY_BASE: 83daf5e7b80d990f037407bab78dff9904aaf3c195a50f84fa8695a22287e707dfbd9524b403b1dcf116ae1d8c06844c3d7ed942564e5b46be6ae3ead93a9d30
 
-  STRIPE_API_KEY: '""'
-  STRIPE_PUBLISHABLE_KEY: '""'
+  STRIPE_API_KEY: ""
+  STRIPE_PUBLISHABLE_KEY: ""
 
   OAUTH_CLIENT_ID: github-oauth-app-id
   OAUTH_CLIENT_SECRET: github-oauth-app-secret
 
-  DEFAULT_HOST: "{{ fab_manager_http_address }}:{{ fab_manager_http_port }}"
+  DEFAULT_HOST: "{{ project_fab_manager_default_host }}"
   DEFAULT_PROTOCOL: "{{ fab_manager_http_schema }}"
 
   DELIVERY_METHOD: smtp
@@ -66,7 +66,7 @@ fab_manager_env:
   SMTP_PASSWORD: password
   SMTP_AUTHENTICATION: plain
   SMTP_ENABLE_STARTTLS_AUTO: "true"
-  SMTP_OPENSSL_VERIFY_MODE: '""'
+  SMTP_OPENSSL_VERIFY_MODE: ""
   SMTP_TLS: "false"
 
   RAILS_LOCALE: en
@@ -78,22 +78,22 @@ fab_manager_env:
   INTL_LOCALE: en-US
   INTL_CURRENCY: USD
   FORCE_VERSION_CHECK: "false"
-  ALLOW_INSECURE_HTTP: "false"
+  ALLOW_INSECURE_HTTP: "true"
 
   POSTGRESQL_LANGUAGE_ANALYZER: english
 
   TIME_ZONE: Asia/Bangkok
   WEEK_STARTING_DAY: monday
-  D3_DATE_FORMAT: '"%Y/%m/%d"'
+  D3_DATE_FORMAT: "%Y/%m/%d"
   UIB_DATE_FORMAT: "yyyy/MM/dd"
   EXCEL_DATE_FORMAT: "dd/mm/yyyy"
 
-  OPENLAB_BASE_URI: '"https://openprojects.fab-manager.com"'
+  OPENLAB_BASE_URI: "https://openprojects.fab-manager.com"
   OPENLAB_SSL_VERIFY: "true"
 
-  ADMINSYS_EMAIL: '"{{ project_fab_manager_admin_user }}"'
-  ADMIN_EMAIL: '"{{ project_fab_manager_admin_user }}"'
-  ADMIN_PASSWORD: '"{{ project_fab_manager_admin_password }}"'
+  ADMINSYS_EMAIL: "{{ project_fab_manager_admin_user }}"
+  ADMIN_EMAIL: "{{ project_fab_manager_admin_user }}"
+  ADMIN_PASSWORD: "{{ project_fab_manager_admin_password }}"
   LOG_LEVEL: debug
   DISK_SPACE_MB_ALERT: 100
   # 5242880 = 5 megabytes
@@ -266,8 +266,8 @@ supervisor_config: |
   [include]
   files = {{ supervisor_conf_d_dir }}/*.conf
 
-  {% set _environment = fab_manager_env.items() | map('join', '=') | join(',') | regex_replace('%', '%%') %}
-  {# ' for vim syntax #}
+  {% set _environment = fab_manager_env.keys() | zip(fab_manager_env.values() | map('regex_replace', '(^.*$)', '\"\\1\"') | map('regex_replace', '%', '%%')) | map('join', '=') | join(',') %}
+  {# " for vim syntax #}
 
   [program:app]
   user={{ fab_manager_user }}

--- a/playbooks/group_vars/staging.yml
+++ b/playbooks/group_vars/staging.yml
@@ -1,1 +1,3 @@
 ---
+
+project_fab_manager_default_host: "{{ ansible_host }}:80"

--- a/playbooks/group_vars/virtualbox.yml
+++ b/playbooks/group_vars/virtualbox.yml
@@ -1,1 +1,3 @@
 ---
+
+project_fab_manager_default_host: 192.168.56.100:80


### PR DESCRIPTION
several causes:

when DEFAULT_HOST is wrong, login attempt fails with "Can't verify CSRF
token authenticity".

as the application runs with RAILS_ENV=production, and TLS is not
enabled, session cookie will not be passed to the application, resulting
the same error.

finally, admin email and password must not be quoted. or the password
would be _"password"_ with quotes.